### PR TITLE
Update Fly.io file to auto start machine to stay online

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -6,13 +6,11 @@
 app = 'fall-2024-security-project'
 primary_region = 'lax'
 
-[build]
-
 [http_service]
   internal_port = 3000
   force_https = true
   auto_stop_machines = 'stop'
-  auto_start_machines = false
+  auto_start_machines = true
   min_machines_running = 0
   processes = ['app']
 


### PR DESCRIPTION
### Description
Make fly.io machines start setting "true" to ensure that app stays online. This was previously set to false to keep from running up the bill when we were in early development stages and didn't need the app online all the time.

### Issue 
N/A

## Additional Information/Screenshots
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
